### PR TITLE
use git commit as version for nightly releases

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,9 +21,9 @@ jobs:
             - name: Grant execute permission for gradlew
               run: chmod +x gradlew
             
-            - name: Configure nightly date
-              id: date
-              run: echo "::set-output name=today::$(date +'%Y-%m-%d')"
+            - name: Get commit hash
+              id: get_hash
+              run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
             
             - name: Set up JDK 17
               uses: actions/setup-java@v3
@@ -39,5 +39,5 @@ jobs:
             - name: Archive Artifacts
               uses: actions/upload-artifact@v2
               with:
-                  name: createbigcannons-1.18.2-nightly-${{ steps.date.outputs.today }}
+                  name: createbigcannons-1.18.2-nightly-${{ steps.get_hash.outputs.sha_short }}
                   path: build/libs/

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,22 @@ plugins {
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.spongepowered.mixin'
 
-version = '1.18.2-0.1-beta'
+def getGitHash = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
+if (cbc_release == "true") {
+    version = "${cbc_minecraft_version}-${cbc_release_version}"
+}
+else {
+    version = "${cbc_minecraft_version}-nightly-${getGitHash}"
+}
+
 group = 'rbasamoyai.createbigcannons' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'createbigcannons'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,10 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mixingradle_version=0.7-SNAPSHOT
 
+cbc_release=false
+cbc_release_version=beta-0.1
+cbc_minecraft_version=1.18.2
+
 jei_minecraft_version=1.18.2
 jei_version=9.7.0.229
 


### PR DESCRIPTION
this makes it easier to report bugs because there might be multiple commits per day