### PR TITLE
🗿 Added an event for when projectiles destroy blocks by penetration, …

### DIFF
--- a/common/src/main/java/rbasamoyai/createbigcannons/base/CBCCommonEvents.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/base/CBCCommonEvents.java
@@ -22,6 +22,7 @@ import rbasamoyai.createbigcannons.crafting.boring.CannonDrillBlock;
 import rbasamoyai.createbigcannons.crafting.builtup.CannonBuilderBlock;
 import rbasamoyai.createbigcannons.crafting.builtup.CannonBuilderBlockEntity;
 import rbasamoyai.createbigcannons.index.CBCBlocks;
+import rbasamoyai.createbigcannons.multiloader.EventsPlatform;
 import rbasamoyai.createbigcannons.munitions.config.BlockHardnessHandler;
 import rbasamoyai.createbigcannons.munitions.config.MunitionPropertiesHandler;
 import rbasamoyai.createbigcannons.network.CBCRootNetwork;
@@ -64,6 +65,11 @@ public class CBCCommonEvents {
 				return;
 			}
 		}
+	}
+
+	public static void onCannonBreakBlock(LevelAccessor level, BlockPos blockPos) {
+		EventsPlatform.postOnCannonBreakBlockEvent(EventsPlatform.createOnCannonBreakBlockEvent(blockPos, level.getBlockState(blockPos)));
+		if (!level.isClientSide()) level.destroyBlock(blockPos, false);
 	}
 
 	private static BlockPos destroyPoleContraption(Block head, Block base, int limit, BlockState state, LevelAccessor level,

--- a/common/src/main/java/rbasamoyai/createbigcannons/base/PartialBlockDamageManager.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/base/PartialBlockDamageManager.java
@@ -96,7 +96,7 @@ public class PartialBlockDamageManager {
 			int newPart = (int) Math.floor(this.blockDamage.get(pos) * hardnessRec);
 
 			if (newPart >= 10) {
-				level.destroyBlock(pos, false);
+				CBCCommonEvents.onCannonBreakBlock(level, pos);
 				this.blockDamage.remove(pos);
 			} else if (newPart - oldPart > 0) {
 				level.destroyBlockProgress(-1, pos, newPart);

--- a/common/src/main/java/rbasamoyai/createbigcannons/multiloader/EventsPlatform.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/multiloader/EventsPlatform.java
@@ -1,0 +1,19 @@
+package rbasamoyai.createbigcannons.multiloader;
+
+import dev.architectury.injectables.annotations.ExpectPlatform;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+import rbasamoyai.createbigcannons.multiloader.event_classes.OnCannonBreakBlock;
+
+public class EventsPlatform {
+
+	@ExpectPlatform
+	public static void postOnCannonBreakBlockEvent(OnCannonBreakBlock event) {
+		throw new AssertionError();
+	}
+
+	@ExpectPlatform
+	public static OnCannonBreakBlock createOnCannonBreakBlockEvent(BlockPos blockPos, BlockState blockState) {
+		throw new AssertionError();
+	}
+}

--- a/common/src/main/java/rbasamoyai/createbigcannons/multiloader/event_classes/OnCannonBreakBlock.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/multiloader/event_classes/OnCannonBreakBlock.java
@@ -1,0 +1,9 @@
+package rbasamoyai.createbigcannons.multiloader.event_classes;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+
+public interface OnCannonBreakBlock {
+	BlockPos getAffectedBlockPos();
+	BlockState getAffectedBlockState();
+}

--- a/common/src/main/java/rbasamoyai/createbigcannons/munitions/big_cannon/AbstractBigCannonProjectile.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/munitions/big_cannon/AbstractBigCannonProjectile.java
@@ -10,6 +10,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
+import rbasamoyai.createbigcannons.base.CBCCommonEvents;
 import rbasamoyai.createbigcannons.config.CBCConfigs;
 import rbasamoyai.createbigcannons.munitions.AbstractCannonProjectile;
 import rbasamoyai.createbigcannons.munitions.config.BlockHardnessHandler;
@@ -50,7 +51,7 @@ public abstract class AbstractBigCannonProjectile extends AbstractCannonProjecti
 		this.setProjectileMass((float) Math.max(startMass - hardness, 0));
 		this.setDeltaMovement(curVel.normalize().scale(Math.max(curPom - hardness, 0) / startMass));
 
-		if (!this.level.isClientSide) this.level.destroyBlock(result.getBlockPos(), false);
+		CBCCommonEvents.onCannonBreakBlock(this.level, result.getBlockPos());
 	}
 
 	@Override

--- a/fabric/src/main/java/rbasamoyai/createbigcannons/fabric/events/OnCannonBreakBlockEvent.java
+++ b/fabric/src/main/java/rbasamoyai/createbigcannons/fabric/events/OnCannonBreakBlockEvent.java
@@ -1,0 +1,17 @@
+package rbasamoyai.createbigcannons.fabric.events;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import rbasamoyai.createbigcannons.multiloader.event_classes.OnCannonBreakBlock;
+
+public interface OnCannonBreakBlockEvent {
+	Event<OnCannonBreakBlockEvent> EVENT = EventFactory.createArrayBacked(OnCannonBreakBlockEvent.class,
+			(listeners) -> (event) -> {
+				for (OnCannonBreakBlockEvent listener : listeners) {
+					listener.OnCannonBreakBlockImpl(event);
+				}
+			}
+	);
+
+	void OnCannonBreakBlockImpl(OnCannonBreakBlock event);
+}

--- a/fabric/src/main/java/rbasamoyai/createbigcannons/fabric/events/OnCannonBreakBlockImpl.java
+++ b/fabric/src/main/java/rbasamoyai/createbigcannons/fabric/events/OnCannonBreakBlockImpl.java
@@ -1,0 +1,23 @@
+package rbasamoyai.createbigcannons.fabric.events;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+import rbasamoyai.createbigcannons.multiloader.event_classes.OnCannonBreakBlock;
+
+public class OnCannonBreakBlockImpl implements OnCannonBreakBlock {
+	private BlockPos blockPos;
+	private BlockState blockState;
+	public OnCannonBreakBlockImpl(BlockPos blockPos, BlockState blockState) {
+		this.blockPos = blockPos;
+		this.blockState = blockState;
+	}
+	@Override
+	public BlockPos getAffectedBlockPos() {
+		return this.blockPos;
+	}
+
+	@Override
+	public BlockState getAffectedBlockState() {
+		return this.blockState;
+	}
+}

--- a/fabric/src/main/java/rbasamoyai/createbigcannons/multiloader/fabric/EventsPlatformImpl.java
+++ b/fabric/src/main/java/rbasamoyai/createbigcannons/multiloader/fabric/EventsPlatformImpl.java
@@ -1,0 +1,17 @@
+package rbasamoyai.createbigcannons.multiloader.fabric;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+import rbasamoyai.createbigcannons.fabric.events.OnCannonBreakBlockEvent;
+import rbasamoyai.createbigcannons.fabric.events.OnCannonBreakBlockImpl;
+import rbasamoyai.createbigcannons.multiloader.event_classes.OnCannonBreakBlock;
+
+public class EventsPlatformImpl {
+	public static void postOnCannonBreakBlockEvent(OnCannonBreakBlock event) {
+		OnCannonBreakBlockEvent.EVENT.invoker().OnCannonBreakBlockImpl(event);
+	}
+
+	public static OnCannonBreakBlock createOnCannonBreakBlockEvent(BlockPos blockPos, BlockState blockState) {
+		return new OnCannonBreakBlockImpl(blockPos, blockState);
+	}
+}

--- a/forge/src/main/java/rbasamoyai/createbigcannons/forge/CBCCommonForgeEvents.java
+++ b/forge/src/main/java/rbasamoyai/createbigcannons/forge/CBCCommonForgeEvents.java
@@ -10,6 +10,7 @@ import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.LogicalSide;
 import rbasamoyai.createbigcannons.base.CBCCommonEvents;
+import rbasamoyai.createbigcannons.forge.events.OnCannonBreakBlockImpl;
 
 public class CBCCommonForgeEvents {
 
@@ -21,6 +22,7 @@ public class CBCCommonForgeEvents {
 		forgeEventBus.addListener(CBCCommonForgeEvents::onServerWorldTick);
 		forgeEventBus.addListener(CBCCommonForgeEvents::onDatapackSync);
 		forgeEventBus.addListener(CBCCommonForgeEvents::onAddReloadListeners);
+		forgeEventBus.register(OnCannonBreakBlockImpl.class);
 	}
 
 	public static void onServerWorldTick(TickEvent.WorldTickEvent evt) {

--- a/forge/src/main/java/rbasamoyai/createbigcannons/forge/events/OnCannonBreakBlockImpl.java
+++ b/forge/src/main/java/rbasamoyai/createbigcannons/forge/events/OnCannonBreakBlockImpl.java
@@ -1,0 +1,21 @@
+package rbasamoyai.createbigcannons.forge.events;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.eventbus.api.Event;
+import rbasamoyai.createbigcannons.multiloader.event_classes.OnCannonBreakBlock;
+
+public class OnCannonBreakBlockImpl extends Event implements OnCannonBreakBlock {
+	private BlockPos blockPos;
+	private BlockState blockState;
+	public OnCannonBreakBlockImpl(BlockPos blockPos, BlockState blockState) {
+		this.blockPos = blockPos;
+		this.blockState = blockState;
+	}
+	public BlockPos getAffectedBlockPos() {
+			return this.blockPos;
+		}
+	public BlockState getAffectedBlockState() {
+		return this.blockState;
+	}
+}

--- a/forge/src/main/java/rbasamoyai/createbigcannons/multiloader/forge/EventsPlatformImpl.java
+++ b/forge/src/main/java/rbasamoyai/createbigcannons/multiloader/forge/EventsPlatformImpl.java
@@ -1,0 +1,19 @@
+package rbasamoyai.createbigcannons.multiloader.forge;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.MinecraftForge;
+import rbasamoyai.createbigcannons.forge.events.OnCannonBreakBlockImpl;
+import rbasamoyai.createbigcannons.multiloader.event_classes.OnCannonBreakBlock;
+
+public class EventsPlatformImpl {
+
+	// Cast is necessary to share the underlying interface.
+	public static void postOnCannonBreakBlockEvent(OnCannonBreakBlock event) {
+		MinecraftForge.EVENT_BUS.post((OnCannonBreakBlockImpl) event);
+	}
+
+	public static OnCannonBreakBlock createOnCannonBreakBlockEvent(BlockPos blockPos, BlockState blockState) {
+		return new OnCannonBreakBlockImpl(blockPos, blockState);
+	}
+}


### PR DESCRIPTION
…-> penetraing only shots are now loggable.

These events track what cannons break by penetration, meaning this now loggable by logging systems and can be used by other mods such as to reverse explosive damage.