### PR TITLE
Tidy up README.md after 5d078ac

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@
 <p><img src="https://i.imgur.com/vzeKdza.png" width="472" height="250"></p>
 <h4><strong>What dependencies are required?</strong></h4>
 <p><a href="https://www.curseforge.com/minecraft/mc-mods/create" rel="nofollow">Create</a> and <a href="https://www.curseforge.com/minecraft/mc-mods/flywheel" rel="nofollow">Flywheel</a>&nbsp;are required. Additionally, <a href="https://www.curseforge.com/minecraft/mc-mods/create-alloyed" rel="nofollow">Create: Alloyed</a> is an optional dependency if you want to access higher tier cannon materials.</p>
-<br>
-<h4><strong>Other FAQ:</strong></h4>
 <p><strong>Will older versions be supported?</strong></p>
-<p>- No, see above if you want to make your own backport though.</p>
+<p>No, although the mod is open source and MIT licensed so feel free to port it yourself.</p>
 <br>
 <p>An rbasamoyai mod.</p>


### PR DESCRIPTION
I noticed that 5d078ac (from my issue #213) left an FAQ answer in the README pointing to the now-removed FAQ answer on a Fabric port. This PR fixes this - I copied the answer from the old version to the new one, and changed "MIT" to "MIT licensed" for clarity. I also removed the "Other FAQ" heading, as having now only one question under it looked off.