### PR TITLE
Changed how serializers were registered

### DIFF
--- a/common/src/main/java/rbasamoyai/createbigcannons/CreateBigCannons.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/CreateBigCannons.java
@@ -16,6 +16,7 @@ import rbasamoyai.createbigcannons.index.CBCBlockEntities;
 import rbasamoyai.createbigcannons.index.CBCBlocks;
 import rbasamoyai.createbigcannons.index.CBCChecks;
 import rbasamoyai.createbigcannons.index.CBCContraptionTypes;
+import rbasamoyai.createbigcannons.index.CBCDataSerializers;
 import rbasamoyai.createbigcannons.index.CBCEntityTypes;
 import rbasamoyai.createbigcannons.index.CBCFluids;
 import rbasamoyai.createbigcannons.index.CBCItems;
@@ -54,10 +55,11 @@ public class CreateBigCannons {
 	static {
 		REGISTRATE.setTooltipModifierFactory(item -> new ItemDescription.Modifier(item, TooltipHelper.Palette.STANDARD_CREATE)
 			.andThen(TooltipModifier.mapNull(KineticStats.create(item))));
+
+		CBCDataSerializers.registerSerializers();
 	}
 
 	public static ResourceLocation resource(String path) {
 		return new ResourceLocation(MOD_ID, path);
 	}
-
 }

--- a/common/src/main/java/rbasamoyai/createbigcannons/index/CBCDataSerializers.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/index/CBCDataSerializers.java
@@ -1,0 +1,29 @@
+package rbasamoyai.createbigcannons.index;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.syncher.EntityDataSerializer;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import rbasamoyai.createbigcannons.munitions.big_cannon.fluid_shell.EndFluidStack;
+
+public class CBCDataSerializers {
+	public static final EntityDataSerializer<EndFluidStack> FLUID_STACK_SERIALIZER = new EntityDataSerializer<>() {
+		@Override
+		public void write(FriendlyByteBuf buf, EndFluidStack fluid) {
+			fluid.writeBuf(buf);
+		}
+
+		@Override
+		public EndFluidStack read(FriendlyByteBuf buf) {
+			return EndFluidStack.readBuf(buf);
+		}
+
+		@Override
+		public EndFluidStack copy(EndFluidStack fluid) {
+			return fluid.copy();
+		}
+	};
+
+	public static void registerSerializers() {
+		EntityDataSerializers.registerSerializer(FLUID_STACK_SERIALIZER);
+	}
+}

--- a/common/src/main/java/rbasamoyai/createbigcannons/munitions/big_cannon/fluid_shell/FluidBlob.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/munitions/big_cannon/fluid_shell/FluidBlob.java
@@ -5,9 +5,7 @@ import com.simibubi.create.foundation.particle.AirParticleData;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.syncher.EntityDataAccessor;
-import net.minecraft.network.syncher.EntityDataSerializer;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.entity.EntityType;
@@ -19,29 +17,12 @@ import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import rbasamoyai.createbigcannons.config.CBCConfigs;
+import rbasamoyai.createbigcannons.index.CBCDataSerializers;
 import rbasamoyai.createbigcannons.munitions.big_cannon.shrapnel.Shrapnel;
 
 public class FluidBlob extends Shrapnel {
-
-	public static final EntityDataSerializer<EndFluidStack> FLUID_STACK_SERIALIZER = new EntityDataSerializer<>() {
-		@Override
-		public void write(FriendlyByteBuf buf, EndFluidStack fluid) {
-			fluid.writeBuf(buf);
-		}
-
-		@Override
-		public EndFluidStack read(FriendlyByteBuf buf) {
-			return EndFluidStack.readBuf(buf);
-		}
-
-		@Override
-		public EndFluidStack copy(EndFluidStack fluid) {
-			return fluid.copy();
-		}
-	};
-
 	private static final EntityDataAccessor<Byte> BLOB_SIZE = SynchedEntityData.defineId(FluidBlob.class, EntityDataSerializers.BYTE);
-	private static final EntityDataAccessor<EndFluidStack> FLUID_STACK = SynchedEntityData.defineId(FluidBlob.class, FLUID_STACK_SERIALIZER);
+	private static final EntityDataAccessor<EndFluidStack> FLUID_STACK = SynchedEntityData.defineId(FluidBlob.class, CBCDataSerializers.FLUID_STACK_SERIALIZER);
 
 	public FluidBlob(EntityType<? extends FluidBlob> type, Level level) {
 		super(type, level);

--- a/fabric/src/main/java/rbasamoyai/createbigcannons/fabric/CreateBigCannonsFabric.java
+++ b/fabric/src/main/java/rbasamoyai/createbigcannons/fabric/CreateBigCannonsFabric.java
@@ -5,7 +5,6 @@ import io.github.fabricators_of_create.porting_lib.util.LazyRegistrar;
 import net.fabricmc.api.ModInitializer;
 import net.minecraft.core.Registry;
 import net.minecraft.core.particles.ParticleType;
-import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraftforge.api.ModLoadingContext;
 import net.minecraftforge.api.fml.event.config.ModConfigEvent;
 import rbasamoyai.createbigcannons.CreateBigCannons;
@@ -15,7 +14,6 @@ import rbasamoyai.createbigcannons.fabric.network.CBCNetworkFabric;
 import rbasamoyai.createbigcannons.index.CBCParticleTypes;
 import rbasamoyai.createbigcannons.index.CBCSoundEvents;
 import rbasamoyai.createbigcannons.munitions.big_cannon.fluid_shell.DefaultFluidCompat;
-import rbasamoyai.createbigcannons.munitions.big_cannon.fluid_shell.FluidBlob;
 
 public class CreateBigCannonsFabric implements ModInitializer {
 
@@ -38,12 +36,5 @@ public class CreateBigCannonsFabric implements ModInitializer {
         ModConfigEvent.RELOADING.register(CBCConfigs::onReload);
 
         CBCCommonFabricEvents.register();
-
-        this.registerSerializers();
     }
-
-    private void registerSerializers() {
-        EntityDataSerializers.registerSerializer(FluidBlob.FLUID_STACK_SERIALIZER);
-    }
-
 }

--- a/forge/src/main/java/rbasamoyai/createbigcannons/forge/CreateBigCannonsForge.java
+++ b/forge/src/main/java/rbasamoyai/createbigcannons/forge/CreateBigCannonsForge.java
@@ -2,7 +2,6 @@ package rbasamoyai.createbigcannons.forge;
 
 import net.minecraft.core.Registry;
 import net.minecraft.core.particles.ParticleType;
-import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -27,7 +26,6 @@ import rbasamoyai.createbigcannons.forge.network.CBCNetworkForge;
 import rbasamoyai.createbigcannons.index.CBCParticleTypes;
 import rbasamoyai.createbigcannons.index.CBCSoundEvents;
 import rbasamoyai.createbigcannons.munitions.big_cannon.fluid_shell.DefaultFluidCompat;
-import rbasamoyai.createbigcannons.munitions.big_cannon.fluid_shell.FluidBlob;
 
 @Mod(CreateBigCannons.MOD_ID)
 public class CreateBigCannonsForge {
@@ -57,8 +55,6 @@ public class CreateBigCannonsForge {
 
         CBCCommonForgeEvents.register(forgeEventBus);
 
-        this.registerSerializers();
-
         DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> CBCClientForge.prepareClient(modEventBus, forgeEventBus));
     }
 
@@ -66,10 +62,6 @@ public class CreateBigCannonsForge {
         CBCNetworkForge.init();
         DefaultFluidCompat.registerMinecraftBlobEffects();
         DefaultFluidCompat.registerCreateBlobEffects();
-    }
-
-    private void registerSerializers() {
-        EntityDataSerializers.registerSerializer(FluidBlob.FLUID_STACK_SERIALIZER);
     }
 
     private void onNewRegistry(NewRegistryEvent evt) {


### PR DESCRIPTION
- Moved FLUID_STACK_SERIALIZER to CBCDataSerializers and statically register them in CreateBigCannons
- Removed registration from platform specific mod classes

This should fix issues where the client is unable to join a server where the serializer was registered at a different point than when the client's serializer was registered.

This is cherry picked from #264 for the 1.18.2/dev branch