### PR TITLE
gradle build fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-XX:MaxRAMPercentage=75 -Xms4G
+org.gradle.jvmargs=-XX:MaxRAMPercentage=75.0 -Xms4G
 org.gradle.parallel=true
 org.gradle.caching=true
 # Mod Info


### PR DESCRIPTION
When building, an error occurs preventing the daemon from starting. This happens when the JVM argument "MaxRAMPercentage=75" is set as an interger rather than a float. settings it to "MaxRAMPercentage=75.0" will solve the issue.

[cmdlog.txt](https://github.com/Cannoneers-of-Create/CreateBigCannons/files/12839871/cmdlog.txt)

This is because older versions of java only use floats for this option but newer versions excepted both integers and floats, so a better default should be a float. The same issue was reported here: (https://github.com/codecentric/helm-charts/issues/195)


