### PR TITLE
Support Copycat blocks copying blast resistance

### DIFF
--- a/common/src/main/java/rbasamoyai/createbigcannons/base/PartialBlockDamageManager.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/base/PartialBlockDamageManager.java
@@ -81,7 +81,7 @@ public class PartialBlockDamageManager {
 				} else {
 					newSet.put(entry.getKey(), newProgress);
 				}
-				double hardnessRec = 1 / BlockHardnessHandler.getHardness(state);
+				double hardnessRec = 1 / BlockHardnessHandler.getHardness(state, level, pos);
 				int oldPart = (int) Math.floor(oldProgress * hardnessRec);
 				int newPart = (int) Math.floor(newProgress * hardnessRec);
 				if (oldPart - newPart > 0) level.destroyBlockProgress(-1, pos, newPart);
@@ -102,7 +102,7 @@ public class PartialBlockDamageManager {
 		int oldProgress = levelSet.getOrDefault(pos, 0);
 		levelSet.merge(pos, added, Integer::sum);
 
-		double hardnessRec = 1 / BlockHardnessHandler.getHardness(state);
+		double hardnessRec = 1 / BlockHardnessHandler.getHardness(state, level, pos);
 		int oldPart = (int) Math.floor(oldProgress * hardnessRec);
 		int newPart = (int) Math.floor(levelSet.get(pos) * hardnessRec);
 

--- a/common/src/main/java/rbasamoyai/createbigcannons/mixin/CopycatMixin.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/mixin/CopycatMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 
 import rbasamoyai.createbigcannons.munitions.config.PropertiesMimicTypeBlock;
@@ -14,7 +15,7 @@ import rbasamoyai.createbigcannons.munitions.config.PropertiesMimicTypeBlock;
 @Mixin(CopycatBlock.class)
 public abstract class CopycatMixin implements PropertiesMimicTypeBlock {
 	@Override
-	public Block createBigCannons$getActualBlock(BlockState state, Level level, BlockPos pos) {
+	public @NotNull Block createBigCannons$getActualBlock(BlockState state, Level level, BlockPos pos) {
 		return CopycatBlock.getMaterial(level, pos).getBlock();
 	}
 }

--- a/common/src/main/java/rbasamoyai/createbigcannons/mixin/CopycatMixin.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/mixin/CopycatMixin.java
@@ -1,21 +1,21 @@
 package rbasamoyai.createbigcannons.mixin;
 
+import javax.annotation.Nonnull;
+
+import org.spongepowered.asm.mixin.Mixin;
+
 import com.simibubi.create.content.decoration.copycat.CopycatBlock;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-
-import org.jetbrains.annotations.NotNull;
-import org.spongepowered.asm.mixin.Mixin;
-
 import rbasamoyai.createbigcannons.munitions.config.PropertiesMimicTypeBlock;
 
 @Mixin(CopycatBlock.class)
 public abstract class CopycatMixin implements PropertiesMimicTypeBlock {
 	@Override
-	public @NotNull Block createBigCannons$getActualBlock(BlockState state, Level level, BlockPos pos) {
+	public @Nonnull Block createBigCannons$getActualBlock(BlockState state, Level level, BlockPos pos) {
 		return CopycatBlock.getMaterial(level, pos).getBlock();
 	}
 }

--- a/common/src/main/java/rbasamoyai/createbigcannons/mixin/CopycatMixin.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/mixin/CopycatMixin.java
@@ -1,0 +1,20 @@
+package rbasamoyai.createbigcannons.mixin;
+
+import com.simibubi.create.content.decoration.copycat.CopycatBlock;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import rbasamoyai.createbigcannons.munitions.config.PropertiesMimicTypeBlock;
+
+@Mixin(CopycatBlock.class)
+public abstract class CopycatMixin implements PropertiesMimicTypeBlock {
+	@Override
+	public Block createBigCannons$getActualBlock(BlockState state, Level level, BlockPos pos) {
+		return CopycatBlock.getMaterial(level, pos).getBlock();
+	}
+}

--- a/common/src/main/java/rbasamoyai/createbigcannons/munitions/AbstractCannonProjectile.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/munitions/AbstractCannonProjectile.java
@@ -170,7 +170,7 @@ public abstract class AbstractCannonProjectile<T extends BaseProjectilePropertie
 
 					double startMass = this.getProjectileMass();
 					double curPom = startMass * mag;
-					double hardness = BlockHardnessHandler.getHardness(state);
+					double hardness = BlockHardnessHandler.getHardness(state, level, bpos);
 
 					if (projCtx.griefState() == GriefState.NO_DAMAGE || state.getDestroySpeed(this.level, bpos) == -1 || curPom < hardness) {
 						this.setInGround(true);
@@ -236,7 +236,7 @@ public abstract class AbstractCannonProjectile<T extends BaseProjectilePropertie
 		Vec3 oldVel = this.getDeltaMovement();
 		double momentum = this.getProjectileMass() * oldVel.length();
 		if (bounce == BounceType.DEFLECT) {
-			if (momentum > BlockHardnessHandler.getHardness(state) * 0.5) {
+			if (momentum > BlockHardnessHandler.getHardness(state, this.level, result.getBlockPos()) * 0.5) {
 				Vec3 spallLoc = this.position().add(oldVel.normalize().scale(2));
 				this.level.explode(null, spallLoc.x, spallLoc.y, spallLoc.z, 2, Explosion.BlockInteraction.NONE);
 			}

--- a/common/src/main/java/rbasamoyai/createbigcannons/munitions/autocannon/AbstractAutocannonProjectile.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/munitions/autocannon/AbstractAutocannonProjectile.java
@@ -84,7 +84,7 @@ public abstract class AbstractAutocannonProjectile<T extends BaseProjectilePrope
 
 			Vec3 curVel = this.getDeltaMovement();
 			double curPom = this.getProjectileMass() * curVel.length();
-			double hardness = BlockHardnessHandler.getHardness(state) * 10;
+			double hardness = BlockHardnessHandler.getHardness(state, this.level, pos) * 10;
 			CreateBigCannons.BLOCK_DAMAGE.damageBlock(pos.immutable(), (int) Math.min(curPom, hardness), state, this.level);
 
 			if (curPom > hardness) {

--- a/common/src/main/java/rbasamoyai/createbigcannons/munitions/big_cannon/AbstractBigCannonProjectile.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/munitions/big_cannon/AbstractBigCannonProjectile.java
@@ -58,7 +58,7 @@ public abstract class AbstractBigCannonProjectile<T extends BigCannonProjectileP
 		double bonus = 1 + Math.max(0, (mag - CBCConfigs.SERVER.munitions.minVelocityForPenetrationBonus.getF())
 			* CBCConfigs.SERVER.munitions.penetrationBonusScale.getF());
 
-		double hardness = BlockHardnessHandler.getHardness(state) / bonus;
+		double hardness = BlockHardnessHandler.getHardness(state, this.level, result.getBlockPos()) / bonus;
 		this.setProjectileMass((float) Math.max(mass - hardness, 0));
 
 		if (!level.isClientSide()) this.level.destroyBlock(result.getBlockPos(), false);

--- a/common/src/main/java/rbasamoyai/createbigcannons/munitions/big_cannon/shrapnel/Shrapnel.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/munitions/big_cannon/shrapnel/Shrapnel.java
@@ -81,7 +81,7 @@ public class Shrapnel extends AbstractHurtingProjectile implements PropertiesMun
 		if (!this.level.isClientSide && state.getDestroySpeed(this.level, pos) != -1 && this.canDestroyBlock(state)) {
 			Vec3 curVel = this.getDeltaMovement();
 			double curPom = this.getProjectileMass() * curVel.length();
-			double hardness = BlockHardnessHandler.getHardness(state) * 10;
+			double hardness = BlockHardnessHandler.getHardness(state, this.level, pos) * 10;
 			CreateBigCannons.BLOCK_DAMAGE.damageBlock(pos.immutable(), (int) Math.min(curPom, hardness), state, this.level);
 
 			SoundType type = state.getSoundType();

--- a/common/src/main/java/rbasamoyai/createbigcannons/munitions/config/BlockHardnessHandler.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/munitions/config/BlockHardnessHandler.java
@@ -4,8 +4,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
 
-import com.simibubi.create.content.decoration.copycat.CopycatBlock;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
@@ -15,7 +13,6 @@ import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.util.profiling.ProfilerFiller;
-import net.minecraft.world.level.ExplosionDamageCalculator;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -23,7 +20,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
 
 public class BlockHardnessHandler {
 
@@ -81,6 +77,7 @@ public class BlockHardnessHandler {
 		TAGS_TO_EVALUATE.clear();
 	}
 
+	@Deprecated
 	public static double getHardness(BlockState state) {
 		Block block = state.getBlock();
 		if (BLOCK_MAP.containsKey(block)) return BLOCK_MAP.get(block);
@@ -90,7 +87,7 @@ public class BlockHardnessHandler {
 
 	public static double getHardness(BlockState state, Level level, BlockPos pos) {
 		Block block = state.getBlock();
-		if (block instanceof CopycatBlock) block = CopycatBlock.getMaterial(level, pos).getBlock();
+		if (block instanceof PropertiesMimicTypeBlock m) block = m.createBigCannons$getActualBlock(state, level, pos);
 		if (BLOCK_MAP.containsKey(block)) return BLOCK_MAP.get(block);
 		if (TAG_MAP.containsKey(block)) return TAG_MAP.get(block);
 		return block.getExplosionResistance();

--- a/common/src/main/java/rbasamoyai/createbigcannons/munitions/config/BlockHardnessHandler.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/munitions/config/BlockHardnessHandler.java
@@ -3,6 +3,10 @@ package rbasamoyai.createbigcannons.munitions.config;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
+
+import com.simibubi.create.content.decoration.copycat.CopycatBlock;
+
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
@@ -11,12 +15,15 @@ import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.util.profiling.ProfilerFiller;
+import net.minecraft.world.level.ExplosionDamageCalculator;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class BlockHardnessHandler {
 
@@ -81,4 +88,11 @@ public class BlockHardnessHandler {
 		return block.getExplosionResistance();
 	}
 
+	public static double getHardness(BlockState state, Level level, BlockPos pos) {
+		Block block = state.getBlock();
+		if (block instanceof CopycatBlock) block = CopycatBlock.getMaterial(level, pos).getBlock();
+		if (BLOCK_MAP.containsKey(block)) return BLOCK_MAP.get(block);
+		if (TAG_MAP.containsKey(block)) return TAG_MAP.get(block);
+		return block.getExplosionResistance();
+	}
 }

--- a/common/src/main/java/rbasamoyai/createbigcannons/munitions/config/InspectResistanceToolItem.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/munitions/config/InspectResistanceToolItem.java
@@ -22,7 +22,7 @@ public class InspectResistanceToolItem extends Item {
 		Level level = ctx.getLevel();
 		if (!level.isClientSide && player != null && !IndexPlatform.isFakePlayer(player)) {
 			String key = "debug." + CreateBigCannons.MOD_ID + ".block_resistance";
-			double hardness = BlockHardnessHandler.getHardness(level.getBlockState(ctx.getClickedPos()));
+			double hardness = BlockHardnessHandler.getHardness(level.getBlockState(ctx.getClickedPos()), level, ctx.getClickedPos());
 			player.displayClientMessage(new TranslatableComponent(key, String.format("%.2f", hardness)), true);
 		}
 		return super.useOn(ctx);

--- a/common/src/main/java/rbasamoyai/createbigcannons/munitions/config/PropertiesMimicTypeBlock.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/munitions/config/PropertiesMimicTypeBlock.java
@@ -5,6 +5,8 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
+import org.jetbrains.annotations.NotNull;
+
 public interface PropertiesMimicTypeBlock {
-	public Block createBigCannons$getActualBlock(BlockState state, Level level, BlockPos pos);
+	@NotNull Block createBigCannons$getActualBlock(BlockState state, Level level, BlockPos pos);
 }

--- a/common/src/main/java/rbasamoyai/createbigcannons/munitions/config/PropertiesMimicTypeBlock.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/munitions/config/PropertiesMimicTypeBlock.java
@@ -1,0 +1,10 @@
+package rbasamoyai.createbigcannons.munitions.config;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+public interface PropertiesMimicTypeBlock {
+	public Block createBigCannons$getActualBlock(BlockState state, Level level, BlockPos pos);
+}

--- a/common/src/main/java/rbasamoyai/createbigcannons/munitions/config/PropertiesMimicTypeBlock.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/munitions/config/PropertiesMimicTypeBlock.java
@@ -1,12 +1,13 @@
 package rbasamoyai.createbigcannons.munitions.config;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
-import org.jetbrains.annotations.NotNull;
-
 public interface PropertiesMimicTypeBlock {
-	@NotNull Block createBigCannons$getActualBlock(BlockState state, Level level, BlockPos pos);
+	@Nonnull
+	Block createBigCannons$getActualBlock(BlockState state, Level level, BlockPos pos);
 }

--- a/common/src/main/resources/createbigcannons-common.mixins.json
+++ b/common/src/main/resources/createbigcannons-common.mixins.json
@@ -19,6 +19,7 @@
     "ArmorStandMixin",
     "BearingCannonDrillFinderMixin",
     "BeltTileEntityMixin",
+    "CopycatMixin",
     "EntityMixin",
     "FilterItemMixin",
     "PlayerMixin",


### PR DESCRIPTION
Added a `BlockHardnessHandler::getHardness` method which takes Create Copycat blocks into consideration, also checking the block/tag map on the copied block.
The parameters differ so I only changed the resistance tool as an example, if this patch is satisfactory then I'll propagate to the rest