### PR TITLE
Fix Mechanical Arm taking too many projectiles

### DIFF
--- a/common/src/main/java/rbasamoyai/createbigcannons/cannons/big_cannons/breeches/quickfiring_breech/CannonMountPoint.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/cannons/big_cannons/breeches/quickfiring_breech/CannonMountPoint.java
@@ -86,7 +86,7 @@ public class CannonMountPoint extends AllArmInteractionPointTypes.DepositOnlyArm
 					breech.setLoadingCooldown(getLoadingCooldown());
 				}
 				if (BigCartridgeBlock.getPowerFromData(firstInfo) == 0) {
-					stack.setCount(1);
+					if (simulate) stack.setCount(1);
 					return cartridge.getExtractedItem(firstInfo);
 				} else {
 					return stack;

--- a/common/src/main/java/rbasamoyai/createbigcannons/cannons/big_cannons/breeches/quickfiring_breech/CannonMountPoint.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/cannons/big_cannons/breeches/quickfiring_breech/CannonMountPoint.java
@@ -85,7 +85,12 @@ public class CannonMountPoint extends AllArmInteractionPointTypes.DepositOnlyArm
 					loadProjectile(stack, munition, poce, bigCannon);
 					breech.setLoadingCooldown(getLoadingCooldown());
 				}
-				return BigCartridgeBlock.getPowerFromData(firstInfo) == 0 ? cartridge.getExtractedItem(firstInfo) : stack;
+				if (BigCartridgeBlock.getPowerFromData(firstInfo) == 0) {
+					stack.setCount(1);
+					return cartridge.getExtractedItem(firstInfo);
+				} else {
+					return stack;
+				}
 			}
 			if (!firstInfo.state.isAir()) return stack;
 			if (!simulate) {


### PR DESCRIPTION
Basic fix that makes the mechanical arm only take (and thus put) one projectile per reload.