### PR TITLE
Prevent cannons from causing explosions to be laggy

### DIFF
--- a/common/src/main/java/rbasamoyai/createbigcannons/cannon_control/contraption/PitchOrientedContraptionEntity.java
+++ b/common/src/main/java/rbasamoyai/createbigcannons/cannon_control/contraption/PitchOrientedContraptionEntity.java
@@ -253,4 +253,8 @@ public class PitchOrientedContraptionEntity extends OrientedContraptionEntity {
 		return super.handlePlayerInteraction(player, localPos, side, interactionHand);
 	}
 
+	@Override
+	public boolean ignoreExplosion() {
+		return true;
+	}
 }


### PR DESCRIPTION
Exempt cannons from the entity part of explosion test, thus saving about 100,000 raycasts per explosion on average.
Side-effects unknown.