### PR TITLE
dependency, bug: Updated Create Big Cannons to 5.7.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ architectury.common(stonecutter.tree.branches.mapNotNull {
 
 repositories {
 	maven("https://mvn.devos.one/snapshots/") // Create Fabric
+	maven("https://mvn.devos.one/releases/") // Porting Lib
 	maven("https://raw.githubusercontent.com/Fuzss/modresources/main/maven/") // Forge Config API Port
 	maven("https://maven.jamieswhiteshirt.com/libs-release") // Reach Entity Attributes
 }
@@ -35,11 +36,9 @@ loom {
 dependencies {
 	minecraft("com.mojang:minecraft:${minecraftVersion}")
 	mappings(loom.layered {
-		mappings("org.quiltmc:quilt-mappings:${minecraftVersion}+build.${mod.dep("qm_version")}:intermediary-v2")
-		parchment("org.parchmentmc.data:parchment-${minecraftVersion}:${mod.dep("parchment_version")}@zip")
 		officialMojangMappings { nameSyntheticMembers = false }
+		parchment("org.parchmentmc.data:parchment-${minecraftVersion}:${mod.dep("parchment_version")}@zip")
 	})
-
 
 	modImplementation("net.fabricmc:fabric-loader:${mod.dep("fabric_loader_version")}")
 	modImplementation("net.fabricmc.fabric-api:fabric-api:${mod.dep("fabric_api_version")}")

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 Changelog
 
+5.7.0
+
+Create Big Cannon 5.7.0. Now supports Create 0.5.1 patch J on Forge/NeoForge and Fabric/Quilt.
+Only 1.20.1 is supported, as Create 0.5.1.j only supports that version. Mod versions on Minecraft 1.18.2 and 1.19.2 will no longer receive support.
+
+Fixed:
+- Updated GoggleOverlayRenderMixin (Fabric)
+
 5.6.0
 
 Create Big Cannons 5.6.0. Now supports Create 0.5.1 patch I.

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -82,7 +82,7 @@ repositories {
 	maven("https://api.modrinth.com/maven") // LazyDFU
 	maven("https://maven.terraformersmc.com/releases/") // Mod Menu
 	maven("https://mvn.devos.one/snapshots/") // Create Fabric, Forge Tags, Milk Lib, Registrate Fabric
-	maven("https://mvn.devos.one/releases") // Porting Lib Releases
+	maven("https://mvn.devos.one/releases/") // Porting Lib Releases
 	maven("https://raw.githubusercontent.com/Fuzss/modresources/main/maven/") // Forge config api port
 	maven("https://maven.cafeteria.dev/releases") // Fake Player API
 	maven("https://maven.jamieswhiteshirt.com/libs-release") // Reach Entity Attributes
@@ -93,9 +93,8 @@ repositories {
 dependencies {
 	minecraft("com.mojang:minecraft:$minecraftVersion")
 	mappings(loom.layered {
-		mappings("org.quiltmc:quilt-mappings:${minecraftVersion}+build.${mod.dep("qm_version")}:intermediary-v2")
-		parchment("org.parchmentmc.data:parchment-${minecraftVersion}:${mod.dep("parchment_version")}@zip")
 		officialMojangMappings { nameSyntheticMembers = false }
+		parchment("org.parchmentmc.data:parchment-${minecraftVersion}:${mod.dep("parchment_version")}@zip")
 	})
 	modImplementation("net.fabricmc:fabric-loader:${mod.dep("fabric_loader")}")
 	modApi("net.fabricmc.fabric-api:fabric-api:${mod.dep("fabric_api_version")}")

--- a/fabric/src/main/java/rbasamoyai/createbigcannons/fabric/mixin/client/GoggleOverlayRendererMixin.java
+++ b/fabric/src/main/java/rbasamoyai/createbigcannons/fabric/mixin/client/GoggleOverlayRendererMixin.java
@@ -8,7 +8,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.llamalad7.mixinextras.sugar.Local;
-import com.mojang.blaze3d.platform.Window;
 import com.simibubi.create.content.equipment.goggles.GoggleOverlayRenderer;
 
 import net.minecraft.client.Minecraft;
@@ -24,7 +23,7 @@ GoggleOverlayRendererMixin {
 
 	@Inject(method = "renderOverlay",
 		at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/ClientLevel;getBlockState(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;", ordinal = 0))
-	private static void createbigcannons$renderOverlay(GuiGraphics graphics, float partialTicks, Window window, CallbackInfo ci,
+	private static void createbigcannons$renderOverlay(GuiGraphics graphics, float partialTicks, int width, int height, CallbackInfo ci,
 													   @Local List<Component> tooltip, @Local ClientLevel level, @Local BlockPos pos) {
 		Minecraft minecraft = Minecraft.getInstance();
 		if (!BlockArmorInspectionToolItem.isHoldingTool(minecraft.player))

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -67,9 +67,8 @@ repositories {
 dependencies {
 	minecraft("com.mojang:minecraft:$minecraftVersion")
 	mappings(loom.layered {
-		mappings("org.quiltmc:quilt-mappings:${minecraftVersion}+build.${mod.dep("qm_version")}:intermediary-v2")
-		parchment("org.parchmentmc.data:parchment-${minecraftVersion}:${mod.dep("parchment_version")}@zip")
 		officialMojangMappings { nameSyntheticMembers = false }
+		parchment("org.parchmentmc.data:parchment-${minecraftVersion}:${mod.dep("parchment_version")}@zip")
 	})
 	"forge"("net.minecraftforge:forge:$minecraftVersion-${common.mod.dep("forge_loader")}")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.caching=true
 
 
 # Mod properties
-mod.version=5.6.0
+mod.version=5.7.0
 mod.group=com.rbasamoyai
 mod.id=createbigcannons
 
@@ -17,6 +17,8 @@ mod.mc_title=[VERSIONED]
 # Space separated versions for publishing. I.e. '1.20, 1.20.1'
 mod.mc_targets=[VERSIONED]
 
+loom.ignoreDependencyLoomVersionValidation=true
+
 # Mod setup
 deps.minecraft_version=1.20.1
 deps.mixin_extras=0.3.5
@@ -27,7 +29,6 @@ deps.neoforge_patch=[VERSIONED]
 
 
 # Mappings
-deps.qm_version=23
 deps.parchment_version=2023.09.03
 
 # Fabric
@@ -35,10 +36,10 @@ deps.fabric_loader_version=0.15.7
 deps.fabric_api_version=0.91.0+1.20.1
 
 # Create - Fabric
-deps.create_fabric_version=0.5.1-h-build.1526+mc1.20.1
+deps.create_fabric_version=0.5.1-j-build.1604+mc1.20.1
 
 # Create - Forge
-deps.create_forge_version=0.5.1.i-51
+deps.create_forge_version=0.5.1.j-55
 deps.registrate_forge_version=MC1.20-1.3.3
 deps.flywheel_forge_minecraft_version=1.20.1
 deps.flywheel_forge_version=0.6.11-13

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.kotlin.dsl.support.uppercaseFirstChar
 plugins {
 	`maven-publish`
 	id("dev.kikugie.stonecutter")
-	id("dev.architectury.loom") version "1.6-SNAPSHOT" apply false
+	id("dev.architectury.loom") version "1.7.+" apply false
 	id("architectury-plugin") version "3.4-SNAPSHOT" apply false
 	id("com.github.johnrengelman.shadow") version "8.1.1" apply false
 }


### PR DESCRIPTION
- Now supports Create 0.5.1 patch J on 1.20.1 Forge/NeoForge and Fabric/Quilt
- Updated GoggleOverlayRenderMixin (Fabric)