### PR TITLE
Unify Screw Breech Directionality

### DIFF
--- a/src/main/java/rbasamoyai/createbigcannons/cannons/big_cannons/breeches/screw_breech/ScrewBreechBlockEntity.java
+++ b/src/main/java/rbasamoyai/createbigcannons/cannons/big_cannons/breeches/screw_breech/ScrewBreechBlockEntity.java
@@ -50,6 +50,8 @@ public class ScrewBreechBlockEntity extends KineticBlockEntity implements IBigCa
 		if (this.getSpeed() == 0) return;
 		float progress = this.getOpeningSpeed();
 		if (Math.abs(progress) > 0) {
+            Direction facing = getBlockState().getValue(BlockStateProperties.FACING);
+			progress = convertToDirection(progress, facing);
 			this.openProgress = Mth.clamp(this.openProgress + progress, 0.0f, 1.0f);
 		}
 
@@ -92,6 +94,8 @@ public class ScrewBreechBlockEntity extends KineticBlockEntity implements IBigCa
 	}
 
 	public float getRenderedBlockOffset(float partialTicks) {
+        Direction facing = getBlockState().getValue(BlockStateProperties.FACING);
+		partialTicks = convertToDirection(partialTicks,facing);
 		return Mth.clamp(this.openProgress + this.getOpeningSpeed() * partialTicks, 0.0f, 1.0f);
 	}
 


### PR DESCRIPTION
adds two direction conversions so screw breeches always have the same behaviour, that being unscrewing when fed counter-clockwise rotation and screwing in when fed clockwise rotation regardless of placement direction

current behaviour is that clockwise rotation will screw in when facing north or west, while unscrewing when facing south or east.

the second convertToDirection for partialTicks is to prevent a visual bug where the screw will jitter frantically while facing east or south.

there's a visual bug induced by this change in behaviour where feeding rotation when the screw breech is facing east or south where the screw visually will rotate opposite of the input rotation, as well as when the screw breech is vertical facing upwards.

I'll also note here: 
this is quite literally the first time I've proposed anything to a github project, at most before this I've screwed around with JSON editing and literally only learned how to use git bash and gradle today. there's probably a more efficient way to do this but I kept getting errors tossed at me and this was the first result that worked fully without a flagrant visual bug.