### PR TITLE
Minor Spelling Fix for en_us Translation

### DIFF
--- a/src/generated/resources/assets/createbigcannons/lang/en_us.json
+++ b/src/generated/resources/assets/createbigcannons/lang/en_us.json
@@ -9,7 +9,7 @@
   "block.createbigcannons.ap_shot.tooltip.summary": "Can effectively _pierce through blocks_. Good against _armored targets_. _Cannot be fuzed and detonated._",
   "block.createbigcannons.autocannon.tooltip.materialProperties": "Autocannon Properties",
   "block.createbigcannons.autocannon.tooltip.maxBarrelLength": "Maximum Length",
-  "block.createbigcannons.autocannon.tooltip.maxBarrelLength.goggles": "_%s blocks_ (including breech)",
+  "block.createbigcannons.autocannon.tooltip.maxBarrelLength.goggles": "_%s blocks_ (including breach)",
   "block.createbigcannons.autocannon.tooltip.weightImpact": "Weight Impact",
   "block.createbigcannons.autocannon.tooltip.weightImpact.goggles": "_%sx RPM_",
   "block.createbigcannons.autocannon_ammo_container": "Autocannon Ammo Container",


### PR DESCRIPTION
Fixed a typo. Was "breech", now is "breach".