### PR TITLE
Use ArrayList in getAllKineticBlockEntities()

### DIFF
--- a/src/main/java/rbasamoyai/createbigcannons/cannon_control/cannon_mount/CannonMountBlockEntity.java
+++ b/src/main/java/rbasamoyai/createbigcannons/cannon_control/cannon_mount/CannonMountBlockEntity.java
@@ -533,7 +533,7 @@ public class CannonMountBlockEntity extends KineticBlockEntity implements IDispl
 
 	@Override
 	public List<KineticBlockEntity> getAllKineticBlockEntities() {
-		return List.of(this.pitchInterface, this.yawInterface);
+        return new java.util.ArrayList<>(List.of(this.pitchInterface, this.yawInterface));
 	}
 
 	public void tryUpdatingSpeed() {


### PR DESCRIPTION
Wrap the return of `getAllKineticBlockEntities()` with `java.util.ArrayList` to fix the error due to an immutable collection with Create Aeronautics, as highlighted in #873.

Closes #873 