### PR TITLE
Fixed Sable shell impact detonation crash

### DIFF
--- a/src/main/java/rbasamoyai/createbigcannons/compat/sable/ShellSubLevelImpactCallback.java
+++ b/src/main/java/rbasamoyai/createbigcannons/compat/sable/ShellSubLevelImpactCallback.java
@@ -1,5 +1,7 @@
 package rbasamoyai.createbigcannons.compat.sable;
 
+import net.minecraft.server.TickTask;
+
 import org.joml.Vector3d;
 
 import dev.ryanhcode.sable.api.physics.callback.BlockSubLevelCollisionCallback;
@@ -51,7 +53,13 @@ public class ShellSubLevelImpactCallback implements BlockSubLevelCollisionCallba
             AbstractCannonProjectile.ImpactResult.KinematicOutcome.STOP, false);
 
         if (fuzeItem.onBlockImpact(fuze, level, blockPos, state, hitResult, impactResult, JOMLConversion.toMojang(hitPos))) {
-            fuzedBlock.detonateProjectileOnTheSpot(level, blockPos, state, shellFacing);
+            level.getServer().tell(new TickTask(level.getServer().getTickCount(), ()->{
+                BlockState currentState = level.getBlockState(blockPos);
+                if(currentState.getBlock() instanceof FuzedProjectileBlock<?,?> currentFuzedBlock){
+                    currentFuzedBlock.detonateProjectileOnTheSpot(level,blockPos,currentState,null);
+                }
+            }));
+            return new CollisionResult(JOMLConversion.ZERO, true);
         } else {
             fuzedBE.setFuze(fuze);
         }


### PR DESCRIPTION
sable$onCollision is called as soon as the fuze touches a physics entity, and it immediately removes blocks on that physics entity causing rapier's voxel data to be invalid. Then you get the rapier rust panic.

The fix is to move it to the next tick so it doesn't happen while rapier is solving