### PR TITLE
Cancellable projectile damage event

### DIFF
--- a/src/main/java/rbasamoyai/createbigcannons/CreateBigCannons.java
+++ b/src/main/java/rbasamoyai/createbigcannons/CreateBigCannons.java
@@ -1,5 +1,7 @@
 package rbasamoyai.createbigcannons;
 
+import net.minecraft.core.BlockPos;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -29,6 +31,7 @@ import rbasamoyai.createbigcannons.index.CBCMunitionPropertiesHandlers;
 import rbasamoyai.createbigcannons.index.CBCRecipeTypes;
 import rbasamoyai.createbigcannons.index.CBCSoundEvents;
 import rbasamoyai.createbigcannons.multiloader.IndexPlatform;
+import rbasamoyai.createbigcannons.munitions.ProjectileDamageHooks;
 import rbasamoyai.createbigcannons.network.CBCRootNetwork;
 import rbasamoyai.createbigcannons.remix.CustomExplosion;
 import rbasamoyai.createbigcannons.utils.CBCUtils;
@@ -81,7 +84,16 @@ public class CreateBigCannons {
 	public static <T extends Explosion & CustomExplosion> void handleCustomExplosion(Level level, T explosion) {
 		if (IndexPlatform.onExplosionStart(level, explosion))
 			return;
+
+        boolean canDamageTerrain = ProjectileDamageHooks.canDamageTerrain(level, BlockPos.containing(explosion.center()));
+        explosion.setCanDamageTerrain(canDamageTerrain);
+
 		explosion.explode();
+
+        if (!canDamageTerrain){
+            explosion.clearToBlow();
+        }
+
 		explosion.finalizeExplosion(level.isClientSide);
 		if (!(level instanceof ServerLevel slevel))
 			return;

--- a/src/main/java/rbasamoyai/createbigcannons/events/ProjectileDamageEvent.java
+++ b/src/main/java/rbasamoyai/createbigcannons/events/ProjectileDamageEvent.java
@@ -1,0 +1,24 @@
+package rbasamoyai.createbigcannons.events;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+
+public class ProjectileDamageEvent extends Event implements ICancellableEvent {
+    private final Level level;
+    private final BlockPos pos;
+
+    public ProjectileDamageEvent(Level level, BlockPos pos){
+        this.level = level;
+        this.pos = pos;
+    }
+
+    public Level getLevel(){
+        return this.level;
+    }
+
+    public BlockPos getPos(){
+        return this.pos;
+    }
+}

--- a/src/main/java/rbasamoyai/createbigcannons/mixin/ExplosionMixin.java
+++ b/src/main/java/rbasamoyai/createbigcannons/mixin/ExplosionMixin.java
@@ -33,7 +33,7 @@ public class ExplosionMixin {
 	private Optional<Float> createbigcannons$explode$editBlock(ExplosionDamageCalculator instance, Explosion explosion, BlockGetter reader,
                                                                BlockPos pos, BlockState state, FluidState fluid, Operation<Optional<Float>> original,
                                                                @Local(ordinal = 0) float power) {
-		if (this instanceof CustomExplosion customExplosion)
+		if (this instanceof CustomExplosion customExplosion && customExplosion.canDamageTerrain())
 			customExplosion.editBlock(this.level, pos, state, fluid, power);
         return original.call(instance, explosion, reader, pos, state, fluid);
     }

--- a/src/main/java/rbasamoyai/createbigcannons/munitions/ProjectileDamageHooks.java
+++ b/src/main/java/rbasamoyai/createbigcannons/munitions/ProjectileDamageHooks.java
@@ -1,0 +1,20 @@
+package rbasamoyai.createbigcannons.munitions;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.common.NeoForge;
+import rbasamoyai.createbigcannons.CBCCompatTransformers;
+import rbasamoyai.createbigcannons.events.ProjectileDamageEvent;
+
+public class ProjectileDamageHooks {
+    private ProjectileDamageHooks(){
+    }
+
+    public static boolean canDamageTerrain(Level level, BlockPos pos){
+        if(level.isClientSide) {
+            return true;
+        }
+        BlockPos realPos = CBCCompatTransformers.transformBlockPos(level, pos);
+        return !NeoForge.EVENT_BUS.post(new ProjectileDamageEvent(level, realPos)).isCanceled();
+    }
+}

--- a/src/main/java/rbasamoyai/createbigcannons/munitions/autocannon/AbstractAutocannonProjectile.java
+++ b/src/main/java/rbasamoyai/createbigcannons/munitions/autocannon/AbstractAutocannonProjectile.java
@@ -31,6 +31,7 @@ import rbasamoyai.createbigcannons.effects.particles.smoke.TrailSmokeParticleDat
 import rbasamoyai.createbigcannons.index.CBCSoundEvents;
 import rbasamoyai.createbigcannons.munitions.AbstractCannonProjectile;
 import rbasamoyai.createbigcannons.munitions.ProjectileContext;
+import rbasamoyai.createbigcannons.munitions.ProjectileDamageHooks;
 import rbasamoyai.createbigcannons.munitions.config.components.BallisticPropertiesComponent;
 import rbasamoyai.createbigcannons.network.ClientboundPlayBlockHitEffectPacket;
 import rbasamoyai.createbigcannons.utils.CBCUtils;
@@ -167,7 +168,7 @@ public abstract class AbstractAutocannonProjectile extends AbstractCannonProject
 
 		BallisticPropertiesComponent ballistics = this.getBallisticProperties();
 		BlockArmorPropertiesProvider blockArmor = BlockArmorPropertiesHandler.getProperties(state);
-		boolean unbreakable = projectileContext.griefState() == CBCCfgMunitions.GriefState.NO_DAMAGE || state.getDestroySpeed(this.level(), pos) == -1;
+		boolean unbreakable = projectileContext.griefState() == CBCCfgMunitions.GriefState.NO_DAMAGE || state.getDestroySpeed(this.level(), pos) == -1 || !ProjectileDamageHooks.canDamageTerrain(this.level(),pos);
 
 		Vec3 accel = this.getForces(this.position(), this.getDeltaMovement());
 		Vec3 curVel = this.getDeltaMovement().add(accel);

--- a/src/main/java/rbasamoyai/createbigcannons/munitions/big_cannon/AbstractBigCannonProjectile.java
+++ b/src/main/java/rbasamoyai/createbigcannons/munitions/big_cannon/AbstractBigCannonProjectile.java
@@ -38,6 +38,7 @@ import rbasamoyai.createbigcannons.munitions.AbstractCannonProjectile;
 import rbasamoyai.createbigcannons.munitions.CannonDamageSource;
 import rbasamoyai.createbigcannons.munitions.ImpactExplosion;
 import rbasamoyai.createbigcannons.munitions.ProjectileContext;
+import rbasamoyai.createbigcannons.munitions.ProjectileDamageHooks;
 import rbasamoyai.createbigcannons.munitions.big_cannon.config.BigCannonProjectilePropertiesComponent;
 import rbasamoyai.createbigcannons.munitions.config.components.BallisticPropertiesComponent;
 import rbasamoyai.createbigcannons.network.ClientboundPlayBlockHitEffectPacket;
@@ -157,7 +158,7 @@ public abstract class AbstractBigCannonProjectile extends AbstractCannonProjecti
 
 		BallisticPropertiesComponent ballistics = this.getBallisticProperties();
 		BlockArmorPropertiesProvider blockArmor = BlockArmorPropertiesHandler.getProperties(state);
-		boolean unbreakable = projectileContext.griefState() == CBCCfgMunitions.GriefState.NO_DAMAGE || state.getDestroySpeed(this.level(), pos) == -1;
+		boolean unbreakable = projectileContext.griefState() == CBCCfgMunitions.GriefState.NO_DAMAGE || state.getDestroySpeed(this.level(), pos) == -1 || !ProjectileDamageHooks.canDamageTerrain(this.level(),pos);
 
 		Vec3 accel = this.getForces(this.position(), this.getDeltaMovement());
 		Vec3 curVel = this.getDeltaMovement().add(accel);

--- a/src/main/java/rbasamoyai/createbigcannons/munitions/big_cannon/shrapnel/ShrapnelBurst.java
+++ b/src/main/java/rbasamoyai/createbigcannons/munitions/big_cannon/shrapnel/ShrapnelBurst.java
@@ -26,6 +26,7 @@ import rbasamoyai.createbigcannons.config.CBCCfgMunitions;
 import rbasamoyai.createbigcannons.config.CBCConfigs;
 import rbasamoyai.createbigcannons.index.CBCDamageTypes;
 import rbasamoyai.createbigcannons.munitions.CannonDamageSource;
+import rbasamoyai.createbigcannons.munitions.ProjectileDamageHooks;
 import rbasamoyai.createbigcannons.munitions.config.components.BallisticPropertiesComponent;
 import rbasamoyai.createbigcannons.munitions.config.components.EntityDamagePropertiesComponent;
 import rbasamoyai.createbigcannons.munitions.fragment_burst.CBCProjectileBurst;
@@ -82,7 +83,9 @@ public class ShrapnelBurst extends CBCProjectileBurst {
                 }
             }
 			BlockPos pos1 = pos.immutable();
-			CreateBigCannons.BLOCK_DAMAGE.damageBlock(pos1, (float) Math.min(curPom, toughness), state, this.level(), PartialBlockDamageManager::voidBlock);
+            if (ProjectileDamageHooks.canDamageTerrain(this.level(),pos1)){
+                CreateBigCannons.BLOCK_DAMAGE.damageBlock(pos1, (float) Math.min(curPom, toughness), state, this.level(), PartialBlockDamageManager::voidBlock);
+            }
 		}
 		if (this.level() instanceof ServerLevel slevel) {
 			ParticleOptions options = new BlockParticleOption(ParticleTypes.BLOCK, state);

--- a/src/main/java/rbasamoyai/createbigcannons/remix/CustomExplosion.java
+++ b/src/main/java/rbasamoyai/createbigcannons/remix/CustomExplosion.java
@@ -24,6 +24,10 @@ public interface CustomExplosion {
 	default void editBlock(Level level, BlockPos pos, BlockState blockState, FluidState fluidState, float power) {
 	}
 
+    void setCanDamageTerrain(boolean canDamageTerrain);
+
+    boolean canDamageTerrain();
+
     float getEntityRadius();
 
 	void sendExplosionToClient(ServerPlayer player);
@@ -37,10 +41,11 @@ public interface CustomExplosion {
 		protected final float blockSize;
         protected final float entitySize;
 		protected final BlockInteraction interaction;
+        protected boolean canDamageTerrain = true;
 
 		public Impl(Level level, @Nullable Entity source, @Nullable DamageSource damageSource,
 					@Nullable ExplosionDamageCalculator calculator, double toBlowX, double toBlowY, double toBlowZ, float blockRadius,
-					float entityRadius, boolean fire, Explosion.BlockInteraction interaction) {
+					float entityRadius, boolean fire, BlockInteraction interaction) {
 			super(level, source, damageSource, calculator, toBlowX, toBlowY, toBlowZ, blockRadius, fire, interaction,
                 ParticleTypes.EXPLOSION, ParticleTypes.EXPLOSION_EMITTER, SoundEvents.GENERIC_EXPLODE); // These last three arguments are unused.
 			this.level = level;
@@ -62,6 +67,16 @@ public interface CustomExplosion {
             this.entitySize = packet.entityPower();
 			this.interaction = BlockInteraction.DESTROY;
 		}
+
+        @Override
+        public void setCanDamageTerrain(boolean canDamageTerrain) {
+            this.canDamageTerrain = canDamageTerrain;
+        }
+
+        @Override
+        public boolean canDamageTerrain() {
+            return this.canDamageTerrain;
+        }
 
 		@Override
 		public void finalizeExplosion(boolean spawnParticles) {


### PR DESCRIPTION
Adds a cancellable event for when a projectile is about to break blocks. This allows other mods to hook into it and cancel it if they want to. Works with blocks on sable sublevels as well. Does not change behavior by default.