### PR TITLE
Fix Create ContinuousOBBCollider null-axis NPE with mounted cannons

### DIFF
--- a/src/main/java/rbasamoyai/createbigcannons/mixin/compat/create/ContinuousSeparationManifoldMixin.java
+++ b/src/main/java/rbasamoyai/createbigcannons/mixin/compat/create/ContinuousSeparationManifoldMixin.java
@@ -1,0 +1,84 @@
+package rbasamoyai.createbigcannons.mixin.compat.create;
+
+import javax.annotation.Nullable;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Create 6.0.x continuous OBB collision can leave {@code axis == null} after SAT
+ * {@code separate()} passes, then NPE when resolving discrete overlaps.
+ * <p>
+ * Hook the package-private manifold at {@code getTimeOfImpact()} (after all separates,
+ * before axis is consumed) and back-fill {@code axis}/{@code separation}.
+ */
+@Mixin(targets = "com.simibubi.create.foundation.collision.ContinuousOBBCollider$ContinuousSeparationManifold", remap = false)
+public abstract class ContinuousSeparationManifoldMixin {
+
+	/** Same sentinel Create assigns in {@code reset()}. */
+	@Unique
+	private static final double UNDEFINED_SEPARATION = Double.MAX_VALUE;
+
+	@Shadow
+	@Final
+    Vec3 stepSeparationAxis;
+
+	@Shadow
+	@Nullable
+    Vec3 axis;
+
+	@Shadow
+	@Nullable
+    Vec3 normalAxis;
+
+	@Shadow
+    double separation;
+
+	@Shadow
+    double normalSeparation;
+
+	@Shadow
+    double stepSeparation;
+
+	@Inject(method = "getTimeOfImpact", at = @At("HEAD"))
+	private void createbigcannons$fillMissingAxis(CallbackInfoReturnable<Double> cir) {
+		if (this.axis != null)
+			return;
+
+		boolean hasNormal = this.normalAxis != null;
+		boolean hasStep = this.stepSeparation < UNDEFINED_SEPARATION;
+
+		if (hasNormal && hasStep) {
+			if (Math.abs(this.normalSeparation) <= Math.abs(this.stepSeparation)) {
+				this.axis = this.normalAxis;
+				this.separation = this.normalSeparation;
+			} else {
+				this.axis = this.stepSeparationAxis;
+				this.separation = this.stepSeparation;
+			}
+			return;
+		}
+		if (hasNormal) {
+			this.axis = this.normalAxis;
+			this.separation = this.normalSeparation;
+			return;
+		}
+		if (hasStep) {
+			this.axis = this.stepSeparationAxis;
+			this.separation = this.stepSeparation;
+			return;
+		}
+
+		// No usable SAT result: keep resolution defined but apply zero push.
+		this.axis = this.stepSeparationAxis;
+		this.separation = 0.0d;
+	}
+
+}

--- a/src/main/resources/createbigcannons.mixins.json
+++ b/src/main/resources/createbigcannons.mixins.json
@@ -33,6 +33,7 @@
     "compat.create.BeltMovementHandlerMixin",
     "compat.create.ChassisBlockEntityMixin",
     "compat.create.ContraptionColliderMixin",
+    "compat.create.ContinuousSeparationManifoldMixin",
     "compat.create.ContraptionMixin",
     "compat.create.FilterItemMixin",
     "compat.create.GantryContraptionMixin",


### PR DESCRIPTION
## Summary
Fixes a server/client tick crash when entities collide with pitch-oriented cannon contraptions on Create 6.0.x.  
Create's `ContinuousOBBCollider.collideMany` can NPE on the discrete collision path:
```text
java.lang.NullPointerException: Cannot read field "x" because "mf.axis" is null
  at ContinuousOBBCollider.collideMany
  at ContraptionCollider.collideEntities
  at ContraptionHandler.tick
```
After `ContinuousSeparationManifold.reset()`, `axis` is `null` until `separate()` assigns it. Long, pitched cannon colliders can finish SAT with only `normalAxis` / `stepSeparation` populated, then crash when the discrete resolver reads `mf.axis.x`.
## Fix
Mixin Create's package-private `ContinuousSeparationManifold` and back-fill a missing `axis` + `separation` at the head of `getTimeOfImpact()` (after all `separate()` calls, before the value is consumed):

1. Prefer `normalAxis` / `normalSeparation` when available
2. Otherwise use `stepSeparationAxis` / `stepSeparation` if step separation was updated
3. If both exist, pick the smaller absolute separation
4. If neither is usable, set `axis = stepSeparationAxis` and `separation = 0` so later reads never see null (no-op push)

This avoids try/catch on the hot path (which caused multi-tick hitches when used as a workaround).
## Notes
- Workaround lives in CBC because the hard crash is easy to hit with pitch-oriented cannon geometry; the missing null-check is in Create 6.0.x.
- Upstream Create fix would be a null-check / guaranteed axis assignment in `ContinuousOBBCollider` itself.