### PR TITLE
Add config entries to control the scale of PlumeParticleData

### DIFF
--- a/src/main/java/rbasamoyai/createbigcannons/cannon_control/contraption/MountedBigCannonContraption.java
+++ b/src/main/java/rbasamoyai/createbigcannons/cannon_control/contraption/MountedBigCannonContraption.java
@@ -484,7 +484,12 @@ public class MountedBigCannonContraption extends AbstractMountedCannonContraptio
 		Vec3 plumePos = CBCCompatTransformers.transformVec3(level, spawnPos.subtract(vec), this.entity.position());
 		propelCtx.smokeScale = Math.max(1, propelCtx.smokeScale);
 
-		BigCannonPlumeParticleData plumeParticle = new BigCannonPlumeParticleData(propelCtx.smokeScale, propelCtx.chargesUsed, 10);
+        float plumeScale = CBCConfigs.server().munitions.smokePlumeSizeMultiplier.getF();
+        BigCannonPlumeParticleData plumeParticle = new BigCannonPlumeParticleData(
+            propelCtx.smokeScale * plumeScale,
+            propelCtx.chargesUsed,
+            10
+        );
 		CannonBlastWaveEffectParticleData blastEffect = new CannonBlastWaveEffectParticleData(shakeDistance,
 			CBCRegistryUtils.getSoundEventRegistry().wrapAsHolder(CBCSoundEvents.FIRE_BIG_CANNON.getMainEvent()), SoundSource.BLOCKS,
 			volume, pitch, 2, propelCtx.chargesUsed);
@@ -712,8 +717,9 @@ public class MountedBigCannonContraption extends AbstractMountedCannonContraptio
 
 		Vec3 plumePos = CBCCompatTransformers.transformVec3(slevel, spawnPos.add(vec), this.entity.position());
         Vec3 plumeDir = CBCCompatTransformers.transformLocationNormal(slevel, this.entity.blockPosition(), vec);
-		for (ServerPlayer player : slevel.players()) {
-			slevel.sendParticles(player, new DropMortarPlumeParticleData(1f), true, plumePos.x, plumePos.y, plumePos.z, 0, plumeDir.x, plumeDir.y, plumeDir.z, 1.0f);
+        float plumeScale = CBCConfigs.server().munitions.dropMortarSmokePlumeSizeMultiplier.getF();
+        for (ServerPlayer player : slevel.players()) {
+            slevel.sendParticles(player, new DropMortarPlumeParticleData(plumeScale), true, plumePos.x, plumePos.y, plumePos.z, 0, plumeDir.x, plumeDir.y, plumeDir.z, 1.0f);
 		}
 		CBCSoundEvents.FIRE_DROP_MORTAR.playOnServer(slevel, BlockPos.containing(spawnPos), 4, slevel.getRandom().nextFloat() * 0.05f + 0.97f);
 		this.hasFired = true;

--- a/src/main/java/rbasamoyai/createbigcannons/config/CBCCfgMunitions.java
+++ b/src/main/java/rbasamoyai/createbigcannons/config/CBCCfgMunitions.java
@@ -90,8 +90,8 @@ public class CBCCfgMunitions extends ConfigBase {
         static String bigCannonProjectileImpactForceMultiplier = "The strength multiplier of big cannon projectile impacts on physics objects (i.e. from Sable, Valkyrien Skies).";
         static String autocannonProjectileImpactForceMultiplier = "The strength multiplier of autocannon projectile impacts (excluding machine gun rounds) on physics objects (i.e. from Sable, Valkyrien Skies).";
         static String machineGunProjectileImpactForceMultiplier = "The strength multiplier of machine gun projectile impacts on physics objects (i.e. from Sable, Valkyrien Skies).";
-	    static String smokePlumeSizeMultiplier = "Multiplier applied to the smoke plume that is generated when a cannon is shot, useful if you are using custom strength values for your cannons.";
-        static String dropMortarSmokePlumeSizeMultiplier = "Multiplier applied to the smoke plume that is generated when a drop mortar is shot.";
+	    static String smokePlumeSizeMultiplier = "Multiplier applied to the smoke plume that is generated when a cannon is fired, useful if you are using custom strength values for your cannons.";
+        static String dropMortarSmokePlumeSizeMultiplier = "Multiplier applied to the smoke plume that is generated when a drop mortar is fired.";
     }
 
 	public enum GriefState {

--- a/src/main/java/rbasamoyai/createbigcannons/config/CBCCfgMunitions.java
+++ b/src/main/java/rbasamoyai/createbigcannons/config/CBCCfgMunitions.java
@@ -12,6 +12,8 @@ public class CBCCfgMunitions extends ConfigBase {
 	public final ConfigFloat baseProjectileFluidBounceChance = f(0.9f, 0, 1, "baseProjectileFluidBounceChance");
 	public final ConfigFloat minVelocityForPenetrationBonus = f(1, 0, "minimumVelocityForPenetrationBonus", "[in Meters per Tick]", Comments.minVelocityForPenetrationBonus);
 	public final ConfigFloat penetrationBonusScale = f(0.1f, 0, "penetrationBonusScale");
+    public final ConfigFloat smokePlumeSizeMultiplier = f(1, 0.1f, 20, "smokePlumeSizeMultiplier", Comments.smokePlumeSizeMultiplier);
+    public final ConfigFloat dropMortarSmokePlumeSizeMultiplier = f(1, 0.1f, 20, "dropMortarSmokePlumeSizeMultiplier", Comments.dropMortarSmokePlumeSizeMultiplier);
 
 	public final ConfigEnum<GriefState> damageRestriction = e(GriefState.ALL_DAMAGE, "damageRestriction", Comments.damageRestriction);
 	public final ConfigBool projectilesChangeSurroundings = b(true, "projectilesChangeSurroundings");
@@ -53,7 +55,6 @@ public class CBCCfgMunitions extends ConfigBase {
 	public final ConfigInt ammoContainerMachineGunRoundCapacity = i(128, 1, 128, "autocannonAmmoContainerMachineGunRoundCapacity", Comments.ammoContainerMachineGunRoundCapacity);
     public final ConfigFloat autocannonProjectileImpactForceMultiplier = f(0.1f, 0, "autocannonProjectileImpactForceMultiplier", Comments.autocannonProjectileImpactForceMultiplier);
     public final ConfigFloat machineGunProjectileImpactForceMultiplier = f(0.01f, 0, "machineGunProjectileImpactForceMultiplier", Comments.machineGunProjectileImpactForceMultiplier);
-
 	@Override
 	public String getName() {
 		return "munitions";
@@ -89,7 +90,9 @@ public class CBCCfgMunitions extends ConfigBase {
         static String bigCannonProjectileImpactForceMultiplier = "The strength multiplier of big cannon projectile impacts on physics objects (i.e. from Sable, Valkyrien Skies).";
         static String autocannonProjectileImpactForceMultiplier = "The strength multiplier of autocannon projectile impacts (excluding machine gun rounds) on physics objects (i.e. from Sable, Valkyrien Skies).";
         static String machineGunProjectileImpactForceMultiplier = "The strength multiplier of machine gun projectile impacts on physics objects (i.e. from Sable, Valkyrien Skies).";
-	}
+	    static String smokePlumeSizeMultiplier = "Multiplier applied to the smoke plume that is generated when a cannon is shot, useful if you are using custom strength values for your cannons.";
+        static String dropMortarSmokePlumeSizeMultiplier = "Multiplier applied to the smoke plume that is generated when a drop mortar is shot.";
+    }
 
 	public enum GriefState {
 		ALL_DAMAGE(Explosion.BlockInteraction.DESTROY_WITH_DECAY),


### PR DESCRIPTION
I was facing an issue of the particles from cannons being fired being too big due to me modifying the datapack values. So I decided to add a config entry so it's possible to fine tune it.

The PR adds two config entries, one for the regular plume and another for the drop mortar one.

I set the max cap to an arbitrary number of 20, which is a lot, and I don't think anyone would reasonably want for it to be any larger, better safe than sorry.